### PR TITLE
Small correction to HexNumber and BinNumber

### DIFF
--- a/construct/text/common.py
+++ b/construct/text/common.py
@@ -225,11 +225,11 @@ def DecNumber(name):
 
 def BinNumber(name):
     """binary number"""
-    return TextualIntAdapter(GreedyRange(Digit(name)), 2)
+    return TextualIntAdapter(GreedyRange(BinDigit(name)), 2)
 
 def HexNumber(name):
     """hexadecimal number"""
-    return TextualIntAdapter(GreedyRange(Digit(name)), 16)
+    return TextualIntAdapter(GreedyRange(HexDigit(name)), 16)
 
 class TextualFloatAdapter(Adapter):
     def _decode(self, obj, context):


### PR DESCRIPTION
- Changed HexNumber and BinNumber to use the correct digits for their respective systems.

Not big changes, but at least for HexNumber it meant that it was failing when to parse your example on the wiki 'c0ffee'.  It would parse, for example '11' just fine, but not '11a' since 'a' wasn't in it's object.

Kindest regards,
Tim
