### PR TITLE
Clean up documentation.

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -453,25 +453,20 @@ class Range(Subconstruct):
     The general-case repeater. Repeats the given unit for at least mincount
     times, and up to maxcount times. If an exception occurs (EOF, validation
     error), the repeater exits. If less than mincount units have been
-    successfully parsed, a RepeaterError is raised.
+    successfully parsed, a RangeError is raised.
 
     .. note::
        This object requires a seekable stream for parsing.
 
-    Parameters:
+    :param int mincount: the minimal count
+    :param int maxcount: the maximal count
+    :param Construct subcon: the subcon to repeat
 
-     * mincount - the minimal count (an integer)
-     * maxcount - the maximal count (an integer)
-     * subcon - the subcon to repeat
-
-    Example:
-    Range(5, 8, UBInt8("foo"))
-
-    >>> c = Repeater(3, 7, UBInt8("foo"))
+    >>> c = Range(3, 7, UBInt8("foo"))
     >>> c.parse("\\x01\\x02")
     Traceback (most recent call last):
       ...
-    construct.core.RepeaterError: expected 3..7, found 2
+    construct.core.RangeError: expected 3..7, found 2
     >>> c.parse("\\x01\\x02\\x03")
     [1, 2, 3]
     >>> c.parse("\\x01\\x02\\x03\\x04\\x05\\x06")
@@ -483,13 +478,13 @@ class Range(Subconstruct):
     >>> c.build([1,2])
     Traceback (most recent call last):
       ...
-    construct.core.RepeaterError: expected 3..7, found 2
+    construct.core.RangeError: expected 3..7, found 2
     >>> c.build([1,2,3,4])
     '\\x01\\x02\\x03\\x04'
     >>> c.build([1,2,3,4,5,6,7,8])
     Traceback (most recent call last):
       ...
-    construct.core.RepeaterError: expected 3..7, found 8
+    construct.core.RangeError: expected 3..7, found 8
     """
 
     __slots__ = ["mincount", "maxcout"]

--- a/construct/macros.py
+++ b/construct/macros.py
@@ -11,9 +11,11 @@ from construct.adapters import (BitIntegerAdapter, PaddingAdapter,
 # fields
 #===============================================================================
 def Field(name, length):
-    """a field
-    * name - the name of the field
-    * length - the length of the field. the length can be either an integer
+    """
+    A field consisting of a specified number of bytes.
+
+    :param str name: the name of the field
+    :param length: the length of the field. the length can be either an integer
       (StaticField), or a function that takes the context as an argument and
       returns the length (MetaField)
     """
@@ -225,9 +227,7 @@ def Array(count, subcon):
     :param int count: number of times to repeat
     :param ``Construct`` subcon: construct to repeat
 
-    >>> c = StrictRepeater(4, UBInt8("foo"))
-    >>> c
-    <Repeater('foo')>
+    >>> c = Array(4, UBInt8("foo"))
     >>> c.parse("\\x01\\x02\\x03\\x04")
     [1, 2, 3, 4]
     >>> c.parse("\\x01\\x02\\x03\\x04\\x05\\x06")
@@ -237,7 +237,7 @@ def Array(count, subcon):
     >>> c.build([5,6,7,8,9])
     Traceback (most recent call last):
       ...
-    construct.core.RepeaterError: expected 4..4, found 5
+    construct.core.RangeError: expected 4..4, found 5
     """
 
     if callable(count):
@@ -270,8 +270,8 @@ def GreedyRange(subcon):
 
     :param ``Construct`` subcon: construct to repeat
 
-    >>> from construct import GreedyRepeater, UBInt8
-    >>> c = GreedyRepeater(UBInt8("foo"))
+    >>> from construct import GreedyRange, UBInt8
+    >>> c = GreedyRange(UBInt8("foo"))
     >>> c.parse("\\x01")
     [1]
     >>> c.parse("\\x01\\x02\\x03")
@@ -281,13 +281,13 @@ def GreedyRange(subcon):
     >>> c.parse("")
     Traceback (most recent call last):
       ...
-    construct.core.RepeaterError: expected 1..2147483647, found 0
+    construct.core.RangeError: expected 1..2147483647, found 0
     >>> c.build([1,2])
     '\\x01\\x02'
     >>> c.build([])
     Traceback (most recent call last):
       ...
-    construct.core.RepeaterError: expected 1..2147483647, found 0
+    construct.core.RangeError: expected 1..2147483647, found 0
     """
 
     return OpenRange(1, subcon)
@@ -299,8 +299,8 @@ def OptionalGreedyRange(subcon):
 
     :param ``Construct`` subcon: construct to repeat
 
-    >>> from construct import OptionalGreedyRepeater, UBInt8
-    >>> c = OptionalGreedyRepeater(UBInt8("foo"))
+    >>> from construct import OptionalGreedyRange, UBInt8
+    >>> c = OptionalGreedyRange(UBInt8("foo"))
     >>> c.parse("")
     []
     >>> c.parse("\\x01\\x02")
@@ -544,7 +544,7 @@ def CString(name, terminators="\x00", encoding=None,
     ``CString`` is similar to the strings of C, C++, and other related
     programming languages.
 
-    By default, the terminator is the NULL byte (0x00).
+    By default, the terminator is the NULL byte (``0x00``).
 
     :param str name: name
     :param iterable terminators: sequence of valid terminators, in order of

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -72,17 +72,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/Reconstruct.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/construct.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/Reconstruct.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/construct.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/Reconstruct"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/Reconstruct"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/construct"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/construct"
 	@echo "# devhelp"
 
 epub:

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -7,11 +7,11 @@ the other "higher" (closer to the python object model). The process of
 converting the lower representation to the higher one is called decoding, and
 the process of converting the higher level representation to the lower one is
 called encoding. Encoding and decoding are expected to be symmetrical, so that
-they counter-act each other (encode(decode(x)) == x and decode(encode(x)) ==
-x).
+they counter-act each other (``encode(decode(x)) == x`` and ``decode(encode(x))
+== x``).
 
 Custom adapter classes derive of the abstract Adapter class, and implement
-their own versions of _encode and _decode, as shown below:
+their own versions of ``_encode`` and ``_decode``, as shown below:
 
 >>> class IpAddressAdapter(Adapter):
 ...     def _encode(self, obj, context):
@@ -53,10 +53,10 @@ having to do so manually every time:
 
 Having the representation separated from the actual parsing or building means
 an adapter is loosely coupled with its underlying construct. As we'll see with
-enums in a moment, we can use the same enum for UBInt8, SLInt32, or LFloat64,
-etc., as long as the underlying construct returns an object we can map.
-Moreover, we can stack several adapters on top of one another, to created a
-nested adapter.
+enums in a moment, we can use the same enum for ``UBInt8``, ``SLInt32``, or
+``LFloat64``, etc., as long as the underlying construct returns an object we
+can map. Moreover, we can stack several adapters on top of one another, to
+created a nested adapter.
 
 Enums
 -----
@@ -64,8 +64,8 @@ Enums
 Enums provide symmetrical name-to-value mapping. The name may be misleading,
 as it's not an enumeration as you would expect in C. But since enums in C are
 often just used as a collection of named values, we'll stick with the name.
-Hint: enums are implemented by the MappingAdapter, which provides mapping of
-values to other values (not necessarily names to numbers).
+Hint: enums are implemented by the ``MappingAdapter``, which provides mapping
+of values to other values (not necessarily names to numbers).
 
 >>> c = Enum(Byte("protocol"),
 ...     TCP = 6,
@@ -73,8 +73,8 @@ values to other values (not necessarily names to numbers).
 ... )
 >>> c
 <MappingAdapter('protocol')>
- 
-# parsing
+
+>>> # parsing
 >>> c.parse("\x06")
 'TCP'
 >>> c.parse("\x11")
@@ -84,8 +84,8 @@ Traceback (most recent call last):
   .
   .
 construct.adapters.MappingAdapterError: undefined mapping for 18
- 
-# building
+
+>>> # building
 >>> c.build("TCP")
 '\x06'
 >>> c.build("UDP")
@@ -94,9 +94,9 @@ construct.adapters.MappingAdapterError: undefined mapping for 18
 
 
 We can also supply a default mapped value when no mapping exists for them. We
-do this by supplying a keyword argument named _default_ (a single uderscore on
-each side). If we don't supply a default value, an exception is raised (as we
-saw in the previous snippet).
+do this by supplying a keyword argument named ``_default_`` (a single uderscore
+on each side). If we don't supply a default value, an exception is raised (as
+we saw in the previous snippet).
 
 >>> c = Enum(Byte("protocol"),
 ...     TCP = 6,
@@ -111,9 +111,9 @@ saw in the previous snippet).
 
 
 We can also just "pass through" unmapped values. We do this by supplying
-_default_ = Pass. If you are curious, Pass is a special construct that "does
-nothing"; in this context, we use it to indicate the Enum to "pass through"
-the unmapped value as-is.
+``_default_ = Pass``. If you are curious, ``Pass`` is a special construct that
+"does nothing"; in this context, we use it to indicate the Enum to "pass
+through" the unmapped value as-is.
 
 >>> c = Enum(Byte("protocol"),
 ...     TCP = 6,
@@ -149,13 +149,13 @@ Validating
 ==========
 
 Validating means making sure the parsed/built object meets a given condition.
-Validators simply raise an exception (ValidatorError) if the object is
-invalid. . The two most common cases already exist as builtins.
+Validators simply raise an exception (``ValidatorError``) if the object is
+invalid. The two most common cases already exist as builtins.
 
 Validators are usually used to make sure a "magic number" is found, the
 correct version of the protocol, a file signature is matched, etc. You can
 write custom validators by deriving from the Validator class and implementing
-the _validate method; this allows you to write validators for more complex
+the ``_validate`` method; this allows you to write validators for more complex
 things, such as making sure a CRC field (or even a cryptographic hash) is
 correct, etc.
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -70,21 +70,21 @@ Building
 
 And here is how we build Structs:
 
-# rebuild the parsed object
+>>> # rebuild the parsed object
 >>> c.build(x)
 '\x07\x00\x01\x00\x00\x00\x01'
  
-# mutate the parsed object and build
+>>> # mutate the parsed object and build
 >>> x.b = 5000
 >>> c.build(x)
 '\x07\x88\x13\x00\x00\x00\x01'
   
-# or we can create a new container
+>>> # or we can create a new container
 >>> c.build(Container(a = 9, b = 1234, c = 56.78))
 '\t\xd2\x04\xb8\x1ecB'
    
-# note: not only containers can be built -- 
-# any object with the required attributes (fully duck typed)
+>>> # note: not only containers can be built --
+>>> # any object with the required attributes (fully duck typed)
 >>> class Foo(object):pass
 ...
 >>> f = Foo()
@@ -238,6 +238,7 @@ wrapper. This will merge the lists of the two sequences.
 [97, 98, 99, 100]
 >>>
 
+.. _repeaters:
 
 Repeaters
 =========
@@ -247,21 +248,21 @@ of times. At this point, we'll only cover static repeaters. Meta repeaters
 will be covered in the Meta constructs tutorial.
 
 We have four kinds of static repeaters. In fact, for those of you who wish to
-go under the hood, three of these repeaters are but wrappers around Repeater.
+go under the hood, two of these repeaters are but wrappers around Range.
 
-.. autofunction:: construct.Repeater
+.. autofunction:: construct.Range
 
-.. autofunction:: construct.StrictRepeater
+.. autofunction:: construct.Array
 
-.. autofunction:: construct.GreedyRepeater
+.. autofunction:: construct.GreedyRange
 
-.. autofunction:: construct.OptionalGreedyRepeater
+.. autofunction:: construct.OptionalGreedyRange
 
 Nesting
 -------
 
 As all constructs, repeaters can be nested too. Here's an example:
 
->>> c = StrictRepeater(5, StrictRepeater(2, UBInt8("foo")))
+>>> c = Array(5, Array(2, UBInt8("foo")))
 >>> c.parse("aabbccddee")
 [[97, 97], [98, 98], [99, 99], [100, 100], [101, 101]]

--- a/docs/bitwise.rst
+++ b/docs/bitwise.rst
@@ -1,3 +1,4 @@
+=======
 History
 =======
 
@@ -10,8 +11,8 @@ or fields that were not aligned to the byte boundary (nibbles et al).
 
 This approach was easy and flexible, but had two main drawbacks:
 
- * Most data is byte-aligned (with very few exceptions)
- * The overhead was too big.
+* Most data is byte-aligned (with very few exceptions)
+* The overhead was too big.
 
 Since constructs worked on bits, the data had to be first converted to a
 bit-string, which meant you had to hold the entire data set in memory. Not
@@ -21,12 +22,12 @@ about 50MB (and that was slow due to page-thrashing).
 
 So as of Construct 2.XX, all constructs work with bytes:
 
- * Less memory consumption
- * No unnecessary bytes-to-bits/bits-to-bytes coversions
- * Can rely on python's built in struct module for numeric packing/unpacking
-   (faster, tested)
- * Can directly parse-from/build-to file-like objects (without in-memory
-   buffering)
+* Less memory consumption
+* No unnecessary bytes-to-bits/bits-to-bytes coversions
+* Can rely on python's built in struct module for numeric packing/unpacking
+  (faster, tested)
+* Can directly parse-from/build-to file-like objects (without in-memory
+  buffering)
 
 But how are we supposed to work with raw bits? The only difference is that we
 must explicitly declare that: BitFields handle parsing/building bit fields,
@@ -46,14 +47,14 @@ Note: BitStruct is actually just a wrapper for the Bitwise construct.
 Important notes
 ---------------
 
- * Non-nestable - BitStructs are not nestable/stackable; writing something
-   like BitStruct("foo", BitStruct("bar", Octet("spam")))} will not work. You
-   can use regular Structs inside BitStructs.
- * Byte-Aligned - The total size of the elements of a BitStruct must be a
-   multiple of 8 (due to alignment issues)
- * Pointers and OnDemand - Do not place Pointers or OnDemands inside
-   BitStructs, since it uses an internal stream, so external stream offsets
-   will turn out wrong.
+* Non-nestable - BitStructs are not nestable/stackable; writing something
+  like ``BitStruct("foo", BitStruct("bar", Octet("spam")))`` will not work. You
+  can use regular Structs inside BitStructs.
+* Byte-Aligned - The total size of the elements of a BitStruct must be a
+  multiple of 8 (due to alignment issues)
+* Pointers and OnDemand - Do not place Pointers or OnDemands inside
+  BitStructs, since it uses an internal stream, so external stream offsets
+  will turn out wrong.
 
 
 BitField

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Reconstruct documentation build configuration file, created by
+# Construct documentation build configuration file, created by
 # sphinx-quickstart on Fri Dec 24 05:23:18 2010.
 #
 # This file is execfile()d with the current directory set to its containing dir.
@@ -40,7 +40,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Reconstruct'
+project = u'Construct'
 copyright = u'2010, Tomer Filiba'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -164,7 +164,7 @@ html_static_path = ['_static']
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Reconstructdoc'
+htmlhelp_basename = 'Constructdoc'
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -178,7 +178,7 @@ htmlhelp_basename = 'Reconstructdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'Reconstruct.tex', u'Reconstruct Documentation',
+  ('index', 'construct.tex', u'Construct Documentation',
    u'Tomer Filiba', 'manual'),
 ]
 
@@ -211,6 +211,6 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'reconstruct', u'Reconstruct Documentation',
+    ('index', 'construct', u'Construct Documentation',
      [u'Tomer Filiba'], 1)
 ]

--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -2,10 +2,12 @@
 Debugging Construct
 ===================
 
-ntro
+Intro
+=====
+
 Programming data structures in Construct is much easier than writing the
 equivalent procedural code, both in terms of RAD and correctness. However,
-sometimes things don't behave the way you expect them to. Yepp, a bug.
+sometimes things don't behave the way you expect them to. Yep, a bug.
 
 Most end-user bugs originate from handling the context wrong. Sometimes you
 forget what nesting level you are at, or you move things around without taking
@@ -13,6 +15,8 @@ into account the nesting, thus breaking context-based expressions. The two
 utilities described below should help you out.
 
 Probe
+=====
+
 The Probe simply dumps information to the screen. It will help you inspect the
 context tree, the stream, and partially constructed objects, so you can
 understand your problem better. It has the same interface as any other field,
@@ -87,64 +91,66 @@ you to hot-fix the error. Then use q to quit the debugger prompt and resume
 normal execution with the fixed value. However, if you don't set self.retval,
 the exception will propagate up.
 
->>> foo = Struct("foo",
-...     UBInt8("bar"),
-...     Debugger(
-...         Enum(UBInt8("spam"),
-...             ABC = 1,
-...             DEF = 2,
-...             GHI = 3,
-...         )
-...     ),
-...     UBInt8("eggs"),
-... )
->>>
->>>
->>> print foo.parse("\x01\x02\x03")
-Container:
-    bar = 1
-    spam = 'DEF'
-    eggs = 3
->>>
->>> print foo.parse("\x01\x04\x03")
-Debugging exception of MappingAdapter('spam'):
-  File "d:\projects\construct\debug.py", line 112, in _parse
-    return self.subcon._parse(stream, context)
-  File "d:\projects\construct\core.py", line 174, in _parse
-    return self._decode(self.subcon._parse(stream, context), context)
-  File "d:\projects\construct\adapters.py", line 77, in _decode
-    raise MappingError("no decoding mapping for %r"  % (obj,))
-MappingError: no decoding mapping for 4
- 
-(you can set the value of 'self.retval', which will be returned)
-> d:\projects\construct\adapters.py(77)_decode()
--> raise MappingError("no decoding mapping for %r"  % (obj,))
-(Pdb)
-(Pdb) u
-> d:\projects\construct\core.py(174)_parse()
--> return self._decode(self.subcon._parse(stream, context), context)
-(Pdb) u
-> d:\projects\construct\debug.py(115)_parse()
--> self.handle_exc("(you can set the value of 'self.retval', "
-(Pdb)
-(Pdb) l
-110         def _parse(self, stream, context):
-111             try:
-112                 return self.subcon._parse(stream, context)
-113             except:
-114                 self.retval = NotImplemented
-115  ->             self.handle_exc("(you can set the value of 'self.retval',
-"
-116                     "which will be returned)")
-117                 if self.retval is NotImplemented:
-118                     raise
-119                 else:
-120                     return self.retval
-(Pdb)
-(Pdb) self.retval = "QWERTY"
-(Pdb) q
-Container:
-    bar = 1
-    spam = 'QWERTY'
-    eggs = 3
->>>
+::
+
+    >>> foo = Struct("foo",
+    ...     UBInt8("bar"),
+    ...     Debugger(
+    ...         Enum(UBInt8("spam"),
+    ...             ABC = 1,
+    ...             DEF = 2,
+    ...             GHI = 3,
+    ...         )
+    ...     ),
+    ...     UBInt8("eggs"),
+    ... )
+    >>>
+    >>>
+    >>> print foo.parse("\x01\x02\x03")
+    Container:
+        bar = 1
+        spam = 'DEF'
+        eggs = 3
+    >>>
+    >>> print foo.parse("\x01\x04\x03")
+    Debugging exception of MappingAdapter('spam'):
+      File "d:\projects\construct\debug.py", line 112, in _parse
+        return self.subcon._parse(stream, context)
+      File "d:\projects\construct\core.py", line 174, in _parse
+        return self._decode(self.subcon._parse(stream, context), context)
+      File "d:\projects\construct\adapters.py", line 77, in _decode
+        raise MappingError("no decoding mapping for %r"  % (obj,))
+    MappingError: no decoding mapping for 4
+
+    (you can set the value of 'self.retval', which will be returned)
+    > d:\projects\construct\adapters.py(77)_decode()
+    -> raise MappingError("no decoding mapping for %r"  % (obj,))
+    (Pdb)
+    (Pdb) u
+    > d:\projects\construct\core.py(174)_parse()
+    -> return self._decode(self.subcon._parse(stream, context), context)
+    (Pdb) u
+    > d:\projects\construct\debug.py(115)_parse()
+    -> self.handle_exc("(you can set the value of 'self.retval', "
+    (Pdb)
+    (Pdb) l
+    110         def _parse(self, stream, context):
+    111             try:
+    112                 return self.subcon._parse(stream, context)
+    113             except:
+    114                 self.retval = NotImplemented
+    115  ->             self.handle_exc("(you can set the value of 'self.retval',
+    "
+    116                     "which will be returned)")
+    117                 if self.retval is NotImplemented:
+    118                     raise
+    119                 else:
+    120                     return self.retval
+    (Pdb)
+    (Pdb) self.retval = "QWERTY"
+    (Pdb) q
+    Container:
+        bar = 1
+        spam = 'QWERTY'
+        eggs = 3
+    >>>

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -3,32 +3,38 @@ Extending Construct
 ===================
 
 Adapters
+========
+
 Adapters are the standard way to extend and customize the library. Adapters
 operate at the object level (unlike constructs, which operate at the stream
 level), and are thus easy to write and more flexible. For more info see, the
 adapter tutorial.
 
-In order to write custom adapters, implement _encode and _decode:
+In order to write custom adapters, implement _encode and _decode::
 
-class MyAdapter(Adapter):
-    def _encode(self, obj, context):
-        # called at building time to return a modified version of obj
-        # reverse version of _decode
-    def _decode(self, obj, context):
-        # called at parsing time to return a modified version of obj
-        # reverse version of _encode
+    class MyAdapter(Adapter):
+        def _encode(self, obj, context):
+            # called at building time to return a modified version of obj
+            # reverse version of _decode
+            ...
+        def _decode(self, obj, context):
+            # called at parsing time to return a modified version of obj
+            # reverse version of _encode
+            ...
 
 
 
 Constructs
+==========
+
 Generally speaking, you should not write constructs by yourself:
 
-    * It's a craft that requires skills and understanding of the internals of
-the library (which change over time).
-    * Adapters should really be all you need and are much more simpler to
-implement.
-    * To make things faster, try using psyco, or write your code in pyrex. The
-python-level classes are as fast as it gets, assuming generality.
+* It's a craft that requires skills and understanding of the internals of the
+  library (which change over time).
+* Adapters should really be all you need and are much more simpler to
+  implement.
+* To make things faster, try using psyco, or write your code in pyrex. The
+  python-level classes are as fast as it gets, assuming generality.
 
 
 The only reason you might want to write a construct is to achieve something
@@ -40,32 +46,42 @@ Union may be a good place to start).
 There are two kinds of constructs: raw construct and subconstructs.
 
 Raw constructs
-Deriving directly of class Construct, raw construct can do as they wish by
-implementing _parse, _build, and _sizeof:
+--------------
 
-class MyConstruct(Construct):
-    def _parse(self, stream, context):
-        # read from the stream (usually not directly)
-        # return object
-    def _build(self, obj, stream, context):
-        # write obj to the stream (usually not directly)
-        # no return value is necessary
-    def _sizeof(self, context):
-        # return computed size, or raise SizeofError if not possible
+Deriving directly of class ``Construct``, raw construct can do as they wish by
+implementing ``_parse``, ``_build``, and ``_sizeof``::
+
+    class MyConstruct(Construct):
+        def _parse(self, stream, context):
+            # read from the stream (usually not directly)
+            # return object
+            ...
+        def _build(self, obj, stream, context):
+            # write obj to the stream (usually not directly)
+            # no return value is necessary
+            ...
+        def _sizeof(self, context):
+            # return computed size, or raise SizeofError if not possible
+            ...
 
 
 Subconstructs
-Deriving of class Subconstruct, subconstructs wrap an inner construct,
-inheriting it's properties (name, flags, etc.). In their _parse and _build
-methods, they will call self.subcon._parse or self.subcon._build respectively.
-Most subconstruct do not need to override _sizeof.
+-------------
 
-class MySubconstruct(Subconstruct):
-    def _parse(self, stream, context):
-        obj = self.subcon._parse(stream, context)
-        # do something with obj
-        # return object
-    def _build(self, obj, stream, context):
-        # do something with obj
-        self.subcon._build(obj, stream, context)
-        # no return value is necessary
+Deriving of class Subconstruct, subconstructs wrap an inner construct,
+inheriting it's properties (name, flags, etc.). In their ``_parse`` and
+``_build`` methods, they will call ``self.subcon._parse`` or
+``self.subcon._build`` respectively. Most subconstruct do not need to override
+``_sizeof``.
+
+::
+
+    class MySubconstruct(Subconstruct):
+        def _parse(self, stream, context):
+            obj = self.subcon._parse(stream, context)
+            # do something with obj
+            # return object
+        def _build(self, obj, stream, context):
+            # do something with obj
+            self.subcon._build(obj, stream, context)
+            # no return value is necessary

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,9 @@
-.. Reconstruct documentation master file, created by
+.. Construct documentation master file, created by
    sphinx-quickstart on Fri Dec 24 05:23:18 2010.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Reconstruct's documentation!
+Welcome to Construct's documentation!
 =======================================
 
 Contents:
@@ -13,7 +13,7 @@ Contents:
 
    basics
    bitwise
-   adaptors
+   adapters
    meta
    string
    misc

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -95,9 +95,9 @@ if "%1" == "qthelp" (
 	echo.
 	echo.Build finished; now you can run "qcollectiongenerator" with the ^
 .qhcp project file in %BUILDDIR%/qthelp, like this:
-	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\Reconstruct.qhcp
+	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\construct.qhcp
 	echo.To view the help file:
-	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\Reconstruct.ghc
+	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\construct.ghc
 	goto end
 )
 

--- a/docs/meta.rst
+++ b/docs/meta.rst
@@ -53,7 +53,7 @@ context.
 
 >>> foo = Struct("foo",
 ...     Byte("length"),
-...     MetaField("data", lambda ctx: ctx["length"] * 2 + 1),  # <-- calculate
+...     Field("data", lambda ctx: ctx.length * 2 + 1),  # <-- calculate
 the length of the string
 ... )
 >>>
@@ -66,7 +66,7 @@ all):
 
 >>> foo = Struct("foo",
 ...     Byte("length"),
-...     MetaField("data", lambda ctx: 7),
+...     Field("data", lambda ctx: 7),
 ... )
 >>>
 >>> foo.parse("\x99abcdefg")
@@ -74,31 +74,30 @@ Container(data = 'abcdefg', length = 153)
 
 
 And here's how we use the special '_' name to get to the upper layer. Here the
-length of the string is calculated as length1 + length2.
+length of the string is calculated as ``length1 + length2``.
 
 >>> foo = Struct("foo",
 ...     Byte("length1"),
 ...     Struct("bar",
 ...         Byte("length2"),
-...         MetaField("data", lambda ctx: ctx["_"]["length1"] +
-ctx["length2"]),
+...         Field("data", lambda ctx: ctx._.length1 + ctx.length2),
 ...     )
 ... )
 >>>
 >>> foo.parse("\x02\x03abcde")
 Container(bar = Container(data = 'abcde', length2 = 3), length1 = 2)
 
-.. autofunction:: construct.MetaField
+.. autofunction:: construct.Field
 
-MetaRepeater
-------------
+Array
+-----
 
-A repeater (construct that repeats a subconstruct) for a variable number of
-times.
+When creating an :ref:`Array <repeaters>`, rather than specifying a constant
+length, you can instead specify that it repeats a variable number of times.
 
 >>> foo = Struct("foo",
 ...     Byte("length"),
-...     MetaRepeater(lambda ctx: ctx["length"], UBInt16("data")),
+...     Array(lambda ctx: ctx.length, UBInt16("data")),
 ... )
 >>>
 >>> foo.parse("\x03\x00\x01\x00\x02\x00\x03")
@@ -134,7 +133,7 @@ statement.
 ...         INT4 = 3,
 ...         STRING = 4,
 ...     ),
-...     Switch("data", lambda ctx: ctx["type"],
+...     Switch("data", lambda ctx: ctx.type,
 ...         {
     ...             "INT1" : UBInt8("spam"),
     ...             "INT2" : UBInt16("spam"),
@@ -165,7 +164,7 @@ the Switch.
 
 >>> foo = Struct("foo",
 ...     Byte("type"),
-...     Switch("data", lambda ctx: ctx["type"],
+...     Switch("data", lambda ctx: ctx.type,
 ...         {
     ...             1 : UBInt8("spam"),
     ...             2 : UBInt16("spam"),
@@ -193,7 +192,7 @@ the stream.
 
 >>> foo = Struct("foo",
 ...     Byte("type"),
-...     Switch("data", lambda ctx: ctx["type"],
+...     Switch("data", lambda ctx: ctx.type,
 ...         {
     ...             1 : UBInt8("spam"),
     ...             2 : UBInt16("spam"),
@@ -244,10 +243,10 @@ stream positions using it. See the following example:
 
 >>> foo = Struct("foo",
 ...     Byte("padding_length"),
-...     MetaPadding(lambda ctx: ctx["padding_length"]),
+...     Padding(lambda ctx: ctx.padding_length),
 ...     Byte("relative_offset"),
 ...     Anchor("absolute_position"),
-...     Pointer(lambda ctx: ctx["absolute_position"] + ctx["relative_offset"],
+...     Pointer(lambda ctx: ctx.absolute_position + ctx.relative_offset,
 ...         Byte("data")
 ...     ),
 ... )

--- a/docs/misc.rst
+++ b/docs/misc.rst
@@ -3,9 +3,13 @@ Miscellaneous
 =============
 
 Conditional
+===========
+
 Optional
+--------
+
 Attempts to parse or build the subconstruct; if it fails, returns a default
-value. By default, the default value is None.
+value. By default, the default value is ``None``.
 
 >>> foo = Optional(UBInt32("foo"))
 >>> foo.parse("\x12\x34\x56\x78")
@@ -21,8 +25,10 @@ None
 
 
 If
+--
+
 Parses or builds the subconstruct only if a certain condition is met.
-Otherwise, returns a default value. By default, the default value is None.
+Otherwise, returns a default value. By default, the default value is ``None``.
 
 >>> foo = Struct("foo",
 ...     Flag("has_options"),
@@ -40,8 +46,10 @@ Container(has_options = False, options = None)
 
 
 IfThenElse
+----------
+
 Branches the construction path based on a given condition. If the condition is
-met, the then_construct is used; otherwise the else_construct is used.
+met, the ``then_construct`` is used; otherwise the ``else_construct`` is used.
 
 >>> foo = Struct("foo",
 ...     Byte("a"),
@@ -58,7 +66,11 @@ Container(a = 2, b = 43707)
 
 
 Alignment and Padding
+=====================
+
 Aligned
+-------
+
 Aligns the subconstruct to a given modulus boundary (default is 4).
 
 >>> foo = Aligned(UBInt8("foo"))
@@ -68,7 +80,10 @@ Aligns the subconstruct to a given modulus boundary (default is 4).
 '\xff\x00\x00\x00'
 
 
-AlignedStruct automatically aligns all the fields of the Struct to the modulus
+AlignedStruct
+-------------
+
+Automatically aligns all the fields of the Struct to the modulus
 boundary.
 
 >>> foo = AlignedStruct("foo",
@@ -83,6 +98,8 @@ Container(a = 1, b = 2)
 
 
 Padding
+-------
+
 Padding is a sequence of bytes of bits that contains no data (its value is
 discarded), and is necessary only for padding, etc.
 
@@ -97,7 +114,11 @@ Container(a = 1, b = 2)
 
 
 Special Constructs
+==================
+
 Rename
+------
+
 Renames a construct.
 
 >>> foo = Struct("foo",
@@ -109,6 +130,8 @@ Container(xxx = 2)
 
 
 Alias
+-----
+
 Creates an alias for an existing field of a Struct.
 
 >>> foo = Struct("foo",
@@ -121,6 +144,8 @@ Container(a = 3, b = 3)
 
 
 Value
+-----
+
 Represents a computed value. Value does not read or write anything to the
 stream; it only returns its computed value as the result.
 
@@ -134,9 +159,11 @@ Container(a = 2, b = 9)
 
 
 Terminator
+----------
+
 Asserts the end of the stream has been reached (so that no more trailing data
 is left unparsed). Note: Terminator is a singleton object. Do not try to
-"instantiate" it (i.e., Terminator()).
+"instantiate" it (i.e., ``Terminator()``).
 
 >>> Terminator.parse("")
 >>> Terminator.parse("x")
@@ -147,14 +174,18 @@ construct.extensions.TerminatorError: end of stream not reached
 
 
 Pass
+----
+
 A do-nothing construct; useful in Switches and Enums. Note: Pass is a
-singleton object. Do not try to "instantiate" it (i.e., Pass()).
+singleton object. Do not try to "instantiate" it (i.e., ``Pass()``).
 
 >>> print Pass.parse("xyz")
 None
 
 
 Const
+-----
+
 A constant value that is required to exist in the data. If the value is not
 matched, ConstError is raised. Useful for magic numbers, signatures, asserting
 correct protocol version, etc.
@@ -171,6 +202,8 @@ construct.extensions.ConstError: expected 'FOOBAR', found 'FOOBAX'
 
 
 Peek
+----
+
 Parses the subconstruct but restores the stream position afterwards
 ("peeking"). Note: works only with seekable streams (in-memory and files).
 
@@ -184,6 +217,8 @@ Container(a = 1, b = 2, c = 2)
 
 
 Union
+-----
+
 Treats the same data as multiple constructs (similar to C's union statement).
 When building, each subconstruct parses the same data (so you can "look" at
 the data in multiple views); when writing, the first subconstruct is used to
@@ -213,6 +248,8 @@ Container:
 
 
 LazyBound
+---------
+
 A lazy-bound construct; it binds to the construct only at runtime. Useful for
 recursive data structures (like linked lists or trees), where a construct
 needs to refer to itself (while it doesn't exist yet).

--- a/docs/text.rst
+++ b/docs/text.rst
@@ -3,6 +3,7 @@ Text parsing
 ============
 
 What has text to do with Construct?
+
 As you already know at this stage of the tutorial, Construct works with binary
 data. That is, all sorts of data structures, file formats, and protocols, that
 have a well defined binary structure. Construct can be used to parse such data
@@ -36,11 +37,17 @@ In order to use the text module, you'll have to explicitly import it.
 
 
 Matching characters
+===================
+
 Char
+----
+
 A single character (1-byte). Note that all characters are assumed to be 8-bit
 ASCII. More complex encoding are left for a higher level.
 
 CharOf
+------
+
 Matches a character that is one of a set of valid characters.
 
 >>> digit = CharOf("digit", "0123456789")
@@ -54,6 +61,8 @@ construct.core.ValidatorError: ('invalid object', 'v')
 
 
 CharNoneOf
+----------
+
 Matches a character that is not part of the set of invalid characters.
 
 >>> nonquote = CharNoneOf("quote", '"')
@@ -67,11 +76,13 @@ construct.core.ValidatorError: ('invalid object', '"')
 
 
 Literal
+-------
+
 Matches a given literal pattern (i.e., a keyword).
 
 >>> while_statement = Struct("while_statement",
 ...     Literal("while"),
-...     GreedyRepeater(CharOf(None, " \t")),
+...     GreedyRange(CharOf(None, " \t")),
 ...     Word("name"),
 ...     Literal(":")
 ... )
@@ -86,6 +97,8 @@ construct.extensions.ConstError: expected 'while', found 'if   '
 
 
 Select
+------
+
 Selects the first matching subconstruct, and uses it for parsing or building.
 The order of the subconstructs is meaningful. Also note that Select can
 operate with seekable streams only (files or in-memory). Raises SelectError if
@@ -112,10 +125,14 @@ no matching subconstruct is found.
 
 
 Constructs for Languages
+========================
+
 These constructs are provided because they are likely to be very useful with
 most common computer languages (C, java, python, ruby, ...)
 
 QuotedString
+------------
+
 A quoted string. You can define the starting and ending quote chars, and
 escape char.
 
@@ -133,9 +150,11 @@ construct.core.EndOfStreamError
 
 
 Whitespace
+----------
+
 Whitespace is a sequence of whitespace chars (by default space and tab) that
 has no programmatic meaning. It is only used to separate tokens or to make the
-code readable. You can specify allow_empty = False, which means that the
+code readable. You can specify ``allow_empty = False``, which means that the
 whitespace is mandatory. Otherwise, whitespace is optional.
 
 >>> Whitespace().parse("  \t")
@@ -143,6 +162,8 @@ whitespace is mandatory. Otherwise, whitespace is optional.
 
 
 DecNumber
+---------
+
 Decimal integral number ((0-9)+). Returns a python integer.
 
 >>> DecNumber("foo").parse("123+456")
@@ -150,6 +171,8 @@ Decimal integral number ((0-9)+). Returns a python integer.
 
 
 HexNumber
+---------
+
 Hexadecimal number ((0-9, A-F, a-f)+). Returns a python integer.
 
 >>> HexNumber("foo").parse("c0ffee")
@@ -157,6 +180,8 @@ Hexadecimal number ((0-9, A-F, a-f)+). Returns a python integer.
 
 
 FloatNumber
+-----------
+
 Floating-pointer number ((0-9)+\.(0-9)+). Returns a python float.
 
 >>> FloatNumber("foo").parse("123.456")
@@ -164,6 +189,8 @@ Floating-pointer number ((0-9)+\.(0-9)+). Returns a python float.
 
 
 Word
+----
+
 A sequence of alpha characters ((A-Z, a-z)+).
 
 >>> Word("foo").parse("hello world")
@@ -171,6 +198,8 @@ A sequence of alpha characters ((A-Z, a-z)+).
 
 
 StringUpto
+----------
+
 A string terminated by some character (similar to CString, but the terminator
 char is not consumed).
 
@@ -179,13 +208,17 @@ char is not consumed).
 
 
 Line
-A text line (terminated by \r or \n)
+----
+
+A text line (terminated by ``\r`` or ``\n``)
 
 >>> Line("foo").parse("hello world\n")
 'hello world'
 
 
 Identifier
+----------
+
 A sequence of alpha-numeric or underscore characters commonly used as
 identifiers in programming languages. The first char must be a alpha or
 underscore (not number).


### PR DESCRIPTION
Fix RST formatting.
Remove references to deprecated names.

Fixes issue #3.
