### PR TITLE
TEST: Fixed paths and made testall xplatform.

### DIFF
--- a/construct/formats/data/cap.py
+++ b/construct/formats/data/cap.py
@@ -34,7 +34,7 @@ cap_file = Struct("cap_file",
 
 
 if __name__ == "__main__":
-    obj = cap_file.parse_stream(open("../../test/cap2.cap", "rb"))
+    obj = cap_file.parse_stream(open("../../tests/cap2.cap", "rb"))
     print len(obj.packets)
 
 

--- a/construct/formats/executable/elf32.py
+++ b/construct/formats/executable/elf32.py
@@ -148,7 +148,7 @@ elf32_file = Struct("elf32_file",
 
 
 if __name__ == "__main__":
-    obj = elf32_file.parse_stream(open("../../test/_ctypes_test.so", "rb"))
+    obj = elf32_file.parse_stream(open("../../tests/_ctypes_test.so", "rb"))
     #[s.data.value for s in obj.sections]
     print obj
 

--- a/construct/formats/executable/pe32.py
+++ b/construct/formats/executable/pe32.py
@@ -404,8 +404,8 @@ pe32_file = Struct("pe32_file",
 
 
 if __name__ == "__main__":
-    print pe32_file.parse_stream(open("../../test/notepad.exe", "rb"))
-    print pe32_file.parse_stream(open("../../test/sqlite3.dll", "rb"))
+    print pe32_file.parse_stream(open("../../tests/NOTEPAD.EXE", "rb"))
+    print pe32_file.parse_stream(open("../../tests/sqlite3.dll", "rb"))
 
 
 

--- a/construct/formats/graphics/bmp.py
+++ b/construct/formats/graphics/bmp.py
@@ -108,6 +108,6 @@ bitmap_file = Struct("bitmap_file",
 
 
 if __name__ == "__main__":
-    obj = bitmap_file.parse_stream(open("../../test/bitmap8.bmp", "rb"))
+    obj = bitmap_file.parse_stream(open("../../tests/bitmap8.bmp", "rb"))
     print obj
     print repr(obj.pixels.value)

--- a/construct/formats/graphics/emf.py
+++ b/construct/formats/graphics/emf.py
@@ -160,7 +160,7 @@ emf_file = Struct("emf_file",
 
 
 if __name__ == "__main__":
-    obj = emf_file.parse_stream(open("../../test/emf1.emf", "rb"))
+    obj = emf_file.parse_stream(open("../../tests/emf1.emf", "rb"))
     print obj
 
 

--- a/construct/tests/testall.py
+++ b/construct/tests/testall.py
@@ -1,4 +1,6 @@
+
 import os
+from subprocess import call
 
 
 basepath = os.path.abspath("..")
@@ -10,7 +12,7 @@ def scan(path, failures):
     elif os.path.isfile(path) and path.endswith(".py"):
         dirname, name = os.path.split(path)
         os.chdir(dirname)
-        errorcode = os.system("python %s > %s 2> %s" % (name, os.devnull, os.devnull))
+        errorcode = call("python %s > %s 2> %s" % (name, os.devnull, os.devnull), shell=True)
         if errorcode != 0:
             failures.append((path, errorcode))
 

--- a/construct/tests/unit.py
+++ b/construct/tests/unit.py
@@ -1,6 +1,7 @@
 import sys
 from construct import *
 from construct.text import *
+from construct.lib import LazyContainer
 
 
 # some tests require doing bad things...


### PR DESCRIPTION
The paths in the formats/\* directory structure referenced 'test' rather
than 'tests'.  In 'tests/testall.py' the system call on Linux returns
256 on success, so shifted to subprocess call since it has a uniform
xplatform response.  The 'tests/unit.py' file required import of
LazyContainer.
