### PR TITLE
TextualAdapter builds incorrect 0 and negative numbers

### DIFF
--- a/construct/tests/unit.py
+++ b/construct/tests/unit.py
@@ -220,8 +220,12 @@ tests = [
     [Identifier("identifier").build, "2c8", None, ValidationError],
     
     [TextualIntAdapter(Field("textintadapter", 3)).parse, "234", 234, None],
+    [TextualIntAdapter(Field("textintadapter", 3)).parse, "-34", -34, None],
+    [TextualIntAdapter(Field("textintadapter", 1)).parse, "0", 0, None],
     [TextualIntAdapter(Field("textintadapter", 3), radix = 16).parse, "234", 0x234, None],
     [TextualIntAdapter(Field("textintadapter", 3)).build, 234, "234", None],
+    [TextualIntAdapter(Field("textintadapter", 3)).build, -34, "-34", None],
+    [TextualIntAdapter(Field("textintadapter", 1)).build, 0, "0", None],
     [TextualIntAdapter(Field("textintadapter", 3), radix = 16).build, 0x234, "234", None],
     # [TextualIntAdapter(Field("textintadapter", 3)).build, 23, "023", None],
     

--- a/construct/text/common.py
+++ b/construct/text/common.py
@@ -202,16 +202,18 @@ class TextualIntAdapter(Adapter):
         self.digits = digits
     def _encode(self, obj, context):
         chars = []
+        n = obj
         if obj < 0:
-            chars.append("-")
-            n = -obj
-        else:
-            n = obj
+            n = -n
+        elif obj == 0:
+            chars.append("0")
         r = self.radix
         digs = self.digits
         while n > 0:
             n, d = divmod(n, r)
             chars.append(digs[d])
+        if obj < 0:
+            chars.append("-")
         # obj2 = "".join(reversed(chars))
         # filler = digs[0] * (self._sizeof(context) - len(obj2))
         # return filler + obj2


### PR DESCRIPTION
the next tests fails:

``` python
>>> from construct import *
>>> from construct.text import *
>>> TextualIntAdapter(Field("textintadapter", 3)).build(-12)
'12-'
>>> TextualIntAdapter(Field("textintadapter", 1)).build(0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "construct/core.py", line 206, in build
    self.build_stream(obj, stream)
  File "construct/core.py", line 214, in build_stream
    self._build(obj, stream, Container())
  File "construct/core.py", line 284, in _build
    self.subcon._build(self._encode(obj, context), stream, context)
  File "construct/core.py", line 324, in _build
    _write_stream(stream, self.length, obj)
  File "construct/core.py", line 306, in _write_stream
    raise FieldError("expected %d, found %d" % (length, len(data)))
construct.core.FieldError: expected 1, found 0
```
