### PR TITLE
makes the bmp format python 3 compatible

### DIFF
--- a/construct/formats/graphics/bmp.py
+++ b/construct/formats/graphics/bmp.py
@@ -55,7 +55,7 @@ rle8pixel = RunLengthAdapter(
 #===============================================================================
 bitmap_file = Struct("bitmap_file",
     # header
-    Const(String("signature", 2), "BM"),
+    Const(String("signature", 2), b"BM"),
     ULInt32("file_size"),
     Padding(4),
     ULInt32("data_offset"),


### PR DESCRIPTION
A bitmap file has to be opened in "rb" mode in python 3, but then b'BM' != 'BM'. Hence the parse function raises an error. This fix should do the trick. Tested with python2.7.6 and python3.4.0
