### PR TITLE
Don't fail on length mismatch, return only the length received

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -296,7 +296,7 @@ def _read_stream(stream, length):
         raise ValueError("length must be >= 0", length)
     data = stream.read(length)
     if len(data) != length:
-        raise FieldError("expected %d, found %d" % (length, len(data)))
+        return data[:len(data)]
     return data
 
 def _write_stream(stream, length, data):


### PR DESCRIPTION
I am not sure why you would want to fail here. Perhaps I'm missing how to deal with this in the client code. Here is an example where this failed before (and it wasn't supposed to):

``` python
import pcap
from construct.protocols.ipstack import ip_stack

def print_packet(pktlen, data, timestamp):
    if not data:
        return

    stack = ip_stack.parse(data)
    print stack.next.next.next


p = pcap.pcapObject()
p.open_live('lo', 1600, 0, 100)
p.setfilter('port 9000', 0, 0)

print 'Press CTRL+C to end capture'
try:
    while True:
        p.dispatch(1, print_packet)
except KeyboardInterrupt:
    print # Empty line where ^C from CTRL+C is displayed
    print '%d packets received, %d packets dropped, %d packets dropped by interface' % p.stats()
```
